### PR TITLE
Fixed Kernel#require_relative

### DIFF
--- a/mrbgems/mruby-require/.travis.yml
+++ b/mrbgems/mruby-require/.travis.yml
@@ -1,0 +1,7 @@
+---
+language: c
+compiler:
+  - clang
+  - gcc
+script:
+  - "make test"

--- a/mrbgems/mruby-require/Makefile
+++ b/mrbgems/mruby-require/Makefile
@@ -1,0 +1,11 @@
+.PHONY : test
+test:
+	ruby ./run_test.rb test
+
+.PHONY : all
+all:
+	echo "NOOP"
+
+.PHONY : clean
+clean:
+	ruby ./run_test.rb clean

--- a/mrbgems/mruby-require/README.md
+++ b/mrbgems/mruby-require/README.md
@@ -1,0 +1,39 @@
+# mruby-require
+
+[![Build Status](https://travis-ci.org/mattn/mruby-require.svg)](https://travis-ci.org/mattn/mruby-require)
+
+mruby-require adds require support to mruby.
+This is based on iij's fork of mruby: https://github.com/iij/mruby
+
+## install by mrbgems
+```ruby
+MRuby::Build.new do |conf|
+  if ENV['OS'] != 'Windows_NT' then
+    conf.cc.flags << %w|-fPIC| # needed for using bundled gems
+  end
+    # ... (snip) ...
+  conf.gem :github => 'mattn/mruby-require'
+end
+```
+
+To work properly, mruby-require must be the last mrbgem specified in the build configuration. Any mrbgem specified *after* mruby-require is compiled as a shared object (`.so`) and put in `build/host/lib` (full path available in `$:`). For loading them at runtime, see the next section.
+
+## Requiring additional mrbgems
+When mruby-require is being used, additional mrbgems that appear *after* mruby-require in build_config.rb must be required to be used. 
+
+For example, if using mruby-onig-regexp, you should add the following to your code:
+
+````ruby
+require 'mruby-onig-regexp'
+````
+
+## Requiring mrbgems in defaults
+Set MRUBY_REQUIRE environment variable as comma separated values like following
+
+```
+MRUBY_REQUIRE=mruby-onig-regexp,mruby-xquote
+```
+
+## License
+
+MIT

--- a/mrbgems/mruby-require/mrbgem.rake
+++ b/mrbgems/mruby-require/mrbgem.rake
@@ -1,0 +1,129 @@
+module MRuby
+  module Gem
+    class List
+      include Enumerable
+      def reject!(&x)
+        @ary.reject! &x
+      end
+      def uniq(&x)
+        @ary.uniq &x
+      end
+    end
+  end
+  class Build
+    unless method_defined?(:old_print_build_summary_for_require)
+      alias_method :old_print_build_summary_for_require, :print_build_summary
+    end
+    def print_build_summary 
+      old_print_build_summary_for_require
+
+      Rake::Task.tasks.each do |t|
+        if t.name =~ /\.so$/
+          t.invoke
+        end
+      end
+
+      unless @bundled.empty?
+        puts "================================================"
+          puts "     Bundled Gems:"
+          @bundled.map(&:name).each do |name|
+          puts "             #{name}"
+        end
+        puts "================================================"
+      end
+    end
+  end
+end
+
+MRuby::Gem::Specification.new('mruby-require') do |spec|
+  spec.license = 'MIT'
+  spec.authors = 'mattn'
+  ENV["MRUBY_REQUIRE"] = ""
+
+  is_vc = ENV['OS'] == 'Windows_NT' && cc.command =~ /^cl(\.exe)?$/
+  is_mingw = ENV['OS'] == 'Windows_NT' && cc.command =~ /^gcc(.*\.exe)?$/
+  top_build_dir = build_dir
+  MRuby.each_target do
+    next if @bundled
+    @bundled = []
+    next unless enable_gems?
+    top_build_dir = build_dir
+    # Only gems included AFTER the mruby-require gem during compilation are 
+    # compiled as separate objects.
+    gems_uniq   = gems.uniq {|x| x.name}
+	mr_position = gems_uniq.find_index {|g| g.name == "mruby-require" }
+    mr_position = -1 if mr_position.nil?
+    compiled_in = gems_uniq[0..mr_position].map {|g| g.name}
+    white_list = ["mruby-require", "mruby-test", "mruby-bin-mrbc"]
+	@bundled    = gems_uniq.reject {|g| compiled_in.include?(g.name)}
+	gems.reject! {|g| !compiled_in.include?(g.name) and !white_list.include?(g.name)}
+    libmruby_libs      = MRuby.targets["host"].linker.libraries
+    libmruby_lib_paths = MRuby.targets["host"].linker.library_paths
+    gems_uniq.each do |g|
+      unless g.name == "mruby-require"
+        begin
+          g.setup
+        rescue
+        end
+        libmruby_libs      += g.linker.libraries
+        libmruby_lib_paths += g.linker.library_paths
+      end
+    end
+    @bundled.each do |g|
+      next if g.objs.nil? or g.objs.empty?
+      ENV["MRUBY_REQUIRE"] += "#{g.name},"
+      sharedlib = "#{top_build_dir}/lib/#{g.name}.so"
+      file sharedlib => g.objs do |t|
+        if RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/
+          libmruby_libs += %w(msvcrt kernel32 user32 gdi32 winspool comdlg32)
+          name = g.name.gsub(/-/, '_')
+          has_rb = !Dir.glob("#{g.dir}/mrblib/*.rb").empty?
+          has_c = !Dir.glob(["#{g.dir}/src/*"]).empty?
+          deffile = "#{build_dir}/lib/#{g.name}.def"
+          open(deffile, 'w') do |f|
+            f.puts %Q[EXPORTS]
+            f.puts %Q[	gem_mrblib_irep_#{name}] if has_rb
+            f.puts %Q[	mrb_#{name}_gem_init] if has_c
+            f.puts %Q[	mrb_#{name}_gem_final] if has_c
+          end
+        else
+          deffile = ''
+        end
+        options = {
+            :flags => [
+                is_vc ? '/DLL' : is_mingw ? '-shared' : '-shared -fPIC',
+                (libmruby_lib_paths + (g.linker ? g.linker.library_paths : [])).flatten.map {|l| is_vc ? "/LIBPATH:#{l}" : "-L#{l}"}].flatten.join(" "),
+            :outfile => sharedlib,
+            :objs => g.objs.flatten.join(" "),
+            :libs => [
+                (is_vc ? '/DEF:' : '') + deffile,
+                libfile("#{build_dir}/lib/libmruby"),
+                libfile("#{build_dir}/lib/libmruby_core"),
+                (libmruby_libs + (g.linker ? g.linker.libraries : [])).flatten.uniq.map {|l| is_vc ? "#{l}.lib" : "-l#{l}"}].flatten.join(" "),
+            :flags_before_libraries => '',
+            :flags_after_libraries => '',
+        }
+
+        _pp "LD", sharedlib
+        sh linker.command + ' ' + (linker.link_options % options)
+      end
+
+      file sharedlib => libfile("#{top_build_dir}/lib/libmruby")
+      Rake::Task.tasks << sharedlib
+    end
+    libmruby.flatten!.reject! do |l|
+      @bundled.reject {|g| l.index(g.name) == nil}.size > 0
+    end
+    cc.include_paths.reject! do |l|
+      @bundled.reject {|g| l.index(g.name) == nil}.size > 0
+    end
+  end
+
+  spec.cc.include_paths << ["#{MRUBY_ROOT}/src"]
+  if RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin/
+    spec.linker.libraries << ['dl']
+    spec.cc.flags << "-DMRBGEMS_ROOT=\\\"#{File.expand_path top_build_dir}/lib\\\""
+  else
+    spec.cc.flags << "-DMRBGEMS_ROOT=\"\"\\\"#{File.expand_path top_build_dir}/lib\\\"\"\""
+  end
+end

--- a/mrbgems/mruby-require/mrblib/mrb_require.rb
+++ b/mrbgems/mruby-require/mrblib/mrb_require.rb
@@ -1,5 +1,6 @@
 
 module Kernel
+=begin
   def require_relative(file,path = nil)
     filename = nil
     unless path
@@ -17,6 +18,7 @@ module Kernel
     filename ||= path
 	  require File.expand_path(file,File.dirname(filename))
   end
+=end
 private
 
   def __call_stack

--- a/mrbgems/mruby-require/mrblib/mrb_require.rb
+++ b/mrbgems/mruby-require/mrblib/mrb_require.rb
@@ -1,0 +1,29 @@
+
+module Kernel
+  def require_relative(file,path = nil)
+    filename = nil
+    unless path
+      call_trace = caller
+      if call_trace.empty?
+        call_trace = __call_stack
+      end
+      filename = call_trace.first
+	    while filename[-1] != ':'
+	      filename.chop!
+	    end
+	    filename.chop!
+	    filename = File.expand_path filename
+    end
+    filename ||= path
+	  require File.expand_path(file,File.dirname(filename))
+  end
+private
+
+  def __call_stack
+    begin; raise ""; rescue => e; end
+    backtrace = e.backtrace
+    backtrace.shift
+    backtrace
+  end
+
+end

--- a/mrbgems/mruby-require/run_test.rb
+++ b/mrbgems/mruby-require/run_test.rb
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+
+if __FILE__ == $PROGRAM_NAME
+  require 'fileutils'
+  FileUtils.mkdir_p 'tmp'
+  unless File.exists?('tmp/mruby')
+    system 'git clone https://github.com/mruby/mruby.git tmp/mruby'
+  end
+  exit system(%Q[cd tmp/mruby; MRUBY_CONFIG=#{File.expand_path __FILE__} ./minirake #{ARGV.join(' ')}])
+end
+
+MRuby::Build.new do |conf|
+  toolchain :clang
+  conf.cc.flags << ["-fPIC"]
+  conf.gem :github => 'mattn/mruby-curl'
+  conf.gem :github => 'mattn/mruby-pcre-regexp'
+  conf.gembox 'default'
+  conf.gem File.dirname(File.expand_path(__FILE__))
+end

--- a/mrbgems/mruby-require/src/mrb_require.c
+++ b/mrbgems/mruby-require/src/mrb_require.c
@@ -1,0 +1,646 @@
+/*
+** require.c - require
+**
+** See Copyright Notice in mruby.h
+*/
+
+#include "mruby.h"
+#include "mruby/data.h"
+#include "mruby/string.h"
+#include "mruby/dump.h"
+#include "mruby/proc.h"
+#include "mruby/compile.h"
+#include "mruby/variable.h"
+#include "mruby/array.h"
+#include "mruby/numeric.h"
+#include "mruby/string.h"
+
+#include "opcode.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <setjmp.h>
+#include <sys/types.h>
+#include <limits.h>
+#include <setjmp.h>
+#if defined(_MSC_VER) || defined(__MINGW32__)
+#ifndef PATH_MAX
+# define PATH_MAX MAX_PATH
+#endif
+#define strdup(x) _strdup(x)
+#else
+#include <sys/param.h>
+#include <unistd.h>
+#include <libgen.h>
+#include <dlfcn.h>
+#endif
+
+/* We can't use MRUBY_RELEASE_NO to determine if byte code implementation is old */
+#ifdef MKOP_A
+#define USE_MRUBY_OLD_BYTE_CODE
+#endif
+
+#ifndef MRB_PROC_TARGET_CLASS
+# define MRB_PROC_TARGET_CLASS(p, c) p->target_class = c
+#endif
+
+#ifdef _WIN32
+#include <windows.h>
+#define dlopen(x,y) (void*)LoadLibrary(x)
+#define dlsym(x,y) (void*)GetProcAddress((HMODULE)x,y)
+#define dlclose(x) FreeLibrary((HMODULE)x)
+const char* dlerror() {
+  DWORD err = (int) GetLastError();
+  static char buf[256];
+  if (err == 0) return NULL;
+  FormatMessage(
+    FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+    NULL,
+    err,
+    MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+    buf,
+    sizeof buf,
+    NULL);
+  return buf;
+}
+
+char*
+realpath(const char *path, char *resolved_path) {
+  if (!resolved_path)
+    resolved_path = malloc(PATH_MAX + 1);
+  if (!resolved_path) return NULL;
+  GetFullPathNameA(path, PATH_MAX, resolved_path, NULL);
+  return resolved_path;
+}
+#else
+#include <dlfcn.h>
+#endif
+
+#if defined(_WIN32)
+# define ENV_SEP ';'
+#else
+# define ENV_SEP ':'
+#endif
+
+#define E_LOAD_ERROR (mrb_class_get(mrb, "LoadError"))
+
+#ifndef MAXPATHLEN
+#define MAXPATHLEN 1024
+#endif
+
+#if 0
+# include <stdarg.h>
+# define debug(s,...) printf("%s:%d " s, __FILE__, __LINE__,__VA_ARGS__)
+#else
+# define debug(...) ((void)0)
+#endif
+
+
+static void
+mrb_load_fail(mrb_state *mrb, mrb_value path, const char *err)
+{
+  mrb_value mesg, exc;
+
+  mesg = mrb_str_new_cstr(mrb, err);
+  mrb_str_cat_lit(mrb, mesg, " -- ");
+  mrb_str_cat_str(mrb, mesg, path);
+  exc = mrb_funcall(mrb, mrb_obj_value(E_LOAD_ERROR), "new", 1, mesg);
+  mrb_iv_set(mrb, exc, mrb_intern_lit(mrb, "path"), path);
+
+  mrb_exc_raise(mrb, exc);
+}
+
+static mrb_value
+envpath_to_mrb_ary(mrb_state *mrb, const char *name)
+{
+  int i;
+  int envlen;
+  mrb_value ary = mrb_ary_new(mrb);
+
+  char *env= getenv(name);
+  if (env == NULL) {
+    return ary;
+  }
+
+  envlen = strlen(env);
+  for (i = 0; i < envlen; i++) {
+    char *ptr = env + i;
+    char *end = strchr(ptr, ENV_SEP);
+    int len;
+    if (end == NULL) {
+      end = env + envlen;
+    }
+    len = end - ptr;
+    mrb_ary_push(mrb, ary, mrb_str_new(mrb, ptr, len));
+    i += len;
+  }
+
+  return ary;
+}
+
+
+static mrb_value
+find_file_check(mrb_state *mrb, mrb_value path, mrb_value fname, mrb_value ext)
+{
+  FILE *fp;
+  char fpath[MAXPATHLEN];
+  mrb_value filepath = mrb_str_dup(mrb, path);
+#ifdef _WIN32
+  if (RSTRING_PTR(fname)[1] == ':') {
+#else
+  if (RSTRING_PTR(fname)[0] == '/') {
+#endif
+    /* when absolute path */
+    mrb_funcall(mrb, filepath, "replace", 1, fname);
+  } else {
+    mrb_str_cat2(mrb, filepath, "/");
+    mrb_str_buf_append(mrb, filepath, fname);
+  }
+
+  if (!mrb_string_p(filepath)) {
+    return mrb_nil_value();
+  }
+  if (mrb_string_p(ext)) {
+    mrb_str_buf_append(mrb, filepath, ext);
+  }
+  debug("filepath: %s\n", RSTRING_PTR(filepath));
+
+  if (realpath(RSTRING_PTR(filepath), fpath) == NULL) {
+    return mrb_nil_value();
+  }
+  debug("fpath: %s\n", fpath);
+
+  fp = fopen(fpath, "r");
+  if (fp == NULL) {
+    return mrb_nil_value();
+  }
+  fclose(fp);
+
+  return mrb_str_new_cstr(mrb, fpath);
+}
+
+static mrb_value
+find_file(mrb_state *mrb, mrb_value filename, int comp)
+{
+  char *ext, *ptr, *tmp;
+  mrb_value exts;
+  int i, j;
+
+  char *fname = RSTRING_PTR(filename);
+  mrb_value filepath = mrb_nil_value();
+  mrb_value load_path = mrb_obj_dup(mrb, mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$:")));
+  load_path = mrb_check_array_type(mrb, load_path);
+
+  if(mrb_nil_p(load_path)) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, "invalid $:");
+    return mrb_undef_value();
+  }
+
+  tmp = ptr = fname;
+  while (tmp) {
+    if ((tmp = strchr(ptr, '/')) || (tmp = strchr(ptr, '\\'))) {
+      ptr = tmp + 1;
+    }
+  }
+
+  ext = strrchr(ptr, '.');
+  exts = mrb_ary_new(mrb);
+  if (ext == NULL && comp) {
+    mrb_ary_push(mrb, exts, mrb_str_new_cstr(mrb, ".rb"));
+    mrb_ary_push(mrb, exts, mrb_str_new_cstr(mrb, ".mrb"));
+    mrb_ary_push(mrb, exts, mrb_str_new_cstr(mrb, ".so"));
+  } else {
+    mrb_ary_push(mrb, exts, mrb_nil_value());
+  }
+
+  /* when a filename start with '.', $: = ['.'] */
+  if (*fname == '.') {
+    load_path = mrb_ary_new(mrb);
+    mrb_ary_push(mrb, load_path, mrb_str_new_cstr(mrb, "."));
+  }
+
+  for (i = 0; i < RARRAY_LEN(load_path); i++) {
+    for (j = 0; j < RARRAY_LEN(exts); j++) {
+      filepath = find_file_check(
+        mrb,
+        mrb_ary_entry(load_path, i),
+        filename,
+        mrb_ary_entry(exts, j));
+      if (!mrb_nil_p(filepath)) {
+        return filepath;
+      }
+    }
+  }
+  mrb_load_fail(mrb, filename, "cannot load such file");
+  return mrb_nil_value();
+}
+
+#ifdef USE_MRUBY_OLD_BYTE_CODE
+static void
+replace_stop_with_return(mrb_state *mrb, mrb_irep *irep)
+{
+  if (irep->iseq[irep->ilen - 1] == MKOP_A(OP_STOP, 0)) {
+    if (irep->flags == MRB_ISEQ_NO_FREE) {
+      mrb_code* iseq = (mrb_code *)mrb_malloc(mrb, (irep->ilen + 1) * sizeof(mrb_code));
+      memcpy(iseq, irep->iseq, irep->ilen * sizeof(mrb_code));
+      irep->iseq = iseq;
+      irep->flags &= ~MRB_ISEQ_NO_FREE;
+    } else {
+      irep->iseq = (mrb_code *)mrb_realloc(mrb, irep->iseq, (irep->ilen + 1) * sizeof(mrb_code));
+    }
+    irep->iseq[irep->ilen - 1] = MKOP_A(OP_LOADNIL, 0);
+    irep->iseq[irep->ilen] = MKOP_AB(OP_RETURN, 0, OP_R_NORMAL);
+    irep->ilen++;
+  }
+}
+#endif
+
+static void
+load_mrb_file(mrb_state *mrb, mrb_value filepath)
+{
+  char *fpath = RSTRING_PTR(filepath);
+  int ai;
+  FILE *fp;
+  mrb_irep *irep;
+
+  fp = fopen(fpath, "rb");
+  if (fp == NULL) {
+    mrb_load_fail(
+      mrb,
+      mrb_str_new_cstr(mrb, fpath),
+      "cannot load such file"
+    );
+    return;
+  }
+
+  ai = mrb_gc_arena_save(mrb);
+
+  irep = mrb_read_irep_file(mrb, fp);
+  fclose(fp);
+
+  mrb_gc_arena_restore(mrb, ai);
+
+  if (irep) {
+    struct RProc *proc;
+    /*
+    size_t i;
+    for (i = sirep; i < mrb->irep_len; i++) {
+      mrb->irep[i]->filename = mrb_string_value_ptr(mrb, filepath);
+    }
+    */
+
+#ifdef USE_MRUBY_OLD_BYTE_CODE
+    replace_stop_with_return(mrb, irep);
+#endif
+    proc = mrb_proc_new(mrb, irep);
+    MRB_PROC_SET_TARGET_CLASS(proc, mrb->object_class);
+
+    ai = mrb_gc_arena_save(mrb);
+    mrb_yield_with_class(mrb, mrb_obj_value(proc), 0, NULL, mrb_top_self(mrb), mrb->object_class);
+    mrb_gc_arena_restore(mrb, ai);
+  } else if (mrb->exc) {
+    // fail to load
+    longjmp(*(jmp_buf*)mrb->jmp, 1);
+  }
+}
+
+static void
+mrb_load_irep_data(mrb_state* mrb, const uint8_t* data)
+{
+  int ai = mrb_gc_arena_save(mrb);
+  mrb_irep *irep = mrb_read_irep(mrb,data);
+  mrb_gc_arena_restore(mrb,ai);
+
+  if (irep) {
+    int ai;
+    struct RProc *proc;
+#ifdef USE_MRUBY_OLD_BYTE_CODE
+    replace_stop_with_return(mrb, irep);
+#endif
+    proc = mrb_proc_new(mrb, irep);
+    MRB_PROC_SET_TARGET_CLASS(proc, mrb->object_class);
+
+    ai = mrb_gc_arena_save(mrb);
+    mrb_yield_with_class(mrb, mrb_obj_value(proc), 0, NULL, mrb_top_self(mrb), mrb->object_class);
+    mrb_gc_arena_restore(mrb, ai);
+  } else if (mrb->exc) {
+    // fail to load
+    longjmp(*(jmp_buf*)mrb->jmp, 1);
+  }
+}
+
+static void
+load_so_file(mrb_state *mrb, mrb_value filepath)
+{
+  char entry[PATH_MAX] = {0}, *ptr, *top, *tmp;
+  char entry_irep[PATH_MAX] = {0};
+  typedef void (*fn_mrb_gem_init)(mrb_state *mrb);
+  fn_mrb_gem_init fn;
+  void * handle = dlopen(RSTRING_PTR(filepath), RTLD_LAZY|RTLD_GLOBAL);
+  const uint8_t* data;
+  if (!handle) {
+    mrb_raise(mrb, E_RUNTIME_ERROR, dlerror());
+  }
+  dlerror(); // clear last error
+
+  tmp = top = ptr = strdup(RSTRING_PTR(filepath));
+  while (tmp) {
+    if ((tmp = strchr(ptr, '/')) || (tmp = strchr(ptr, '\\'))) {
+      ptr = tmp + 1;
+    }
+  }
+
+  tmp = strrchr(ptr, '.');
+  if (tmp) *tmp = 0;
+  tmp = ptr;
+  while (*tmp) {
+    if (*tmp == '-') *tmp = '_';
+    tmp++;
+  }
+  snprintf(entry, sizeof(entry)-1, "mrb_%s_gem_init", ptr);
+  snprintf(entry_irep, sizeof(entry_irep)-1, "gem_mrblib_irep_%s", ptr);
+  fn = (fn_mrb_gem_init) dlsym(handle, entry);
+  data = (const uint8_t *)dlsym(handle, entry_irep);
+  free(top);
+  if (!fn && !data) {
+      mrb_load_fail(mrb, filepath, "cannot load such file");
+  }
+
+  if (fn != NULL) {
+    int ai = mrb_gc_arena_save(mrb);
+    fn(mrb);
+    mrb_gc_arena_restore(mrb, ai);
+  }
+  dlerror(); // clear last error
+
+  if (data != NULL) {
+    mrb_load_irep_data(mrb, data);
+  }
+}
+
+static void
+unload_so_file(mrb_state *mrb, mrb_value filepath)
+{
+  char entry[PATH_MAX] = {0}, *ptr, *top, *tmp;
+  typedef void (*fn_mrb_gem_final)(mrb_state *mrb);
+  fn_mrb_gem_final fn;
+  void * handle = dlopen(RSTRING_PTR(filepath), RTLD_LAZY|RTLD_GLOBAL);
+  if (!handle) {
+    return;
+  }
+
+  tmp = top = ptr = strdup(RSTRING_PTR(filepath));
+  while (tmp) {
+    if ((tmp = strchr(ptr, '/')) || (tmp = strchr(ptr, '\\'))) {
+      ptr = tmp + 1;
+    }
+  }
+
+  tmp = strrchr(ptr, '.');
+  if (tmp) *tmp = 0;
+  tmp = ptr;
+  while (*tmp) {
+    if (*tmp == '-') *tmp = '_';
+    tmp++;
+  }
+  snprintf(entry, sizeof(entry)-1, "mrb_%s_gem_final", ptr);
+
+  fn = (fn_mrb_gem_final) dlsym(handle, entry);
+  free(top);
+  if (fn == NULL) {
+    return;
+  }
+
+  fn(mrb);
+}
+
+static void
+load_rb_file(mrb_state *mrb, mrb_value filepath)
+{
+  FILE *fp;
+  char *fpath = RSTRING_PTR(filepath);
+  mrbc_context *mrbc_ctx;
+  int ai = mrb_gc_arena_save(mrb);
+
+  fp = fopen((const char*)fpath, "r");
+  if (fp == NULL) {
+    mrb_load_fail(mrb, filepath, "cannot load such file");
+    return;
+  }
+
+  mrbc_ctx = mrbc_context_new(mrb);
+
+  mrbc_filename(mrb, mrbc_ctx, fpath);
+  mrb_load_file_cxt(mrb, fp, mrbc_ctx);
+  fclose(fp);
+
+  mrb_gc_arena_restore(mrb, ai);
+  mrbc_context_free(mrb, mrbc_ctx);
+}
+
+static void
+load_file(mrb_state *mrb, mrb_value filepath)
+{
+  char *ext = strrchr(RSTRING_PTR(filepath), '.');
+
+  if (!ext || strcmp(ext, ".rb") == 0) {
+    load_rb_file(mrb, filepath);
+  } else if (strcmp(ext, ".mrb") == 0) {
+    load_mrb_file(mrb, filepath);
+  } else if (strcmp(ext, ".so") == 0 ||
+             strcmp(ext, ".dll") == 0 ||
+             strcmp(ext, ".dylib") == 0) {
+    load_so_file(mrb, filepath);
+  } else {
+    load_rb_file(mrb, filepath);
+  }
+}
+
+mrb_value
+mrb_load(mrb_state *mrb, mrb_value filename)
+{
+  mrb_value filepath = find_file(mrb, filename, 0);
+  load_file(mrb, filepath);
+  return mrb_true_value(); // TODO: ??
+}
+
+mrb_value
+mrb_f_load(mrb_state *mrb, mrb_value self)
+{
+  mrb_value filename;
+
+  mrb_get_args(mrb, "o", &filename);
+  if (mrb_type(filename) != MRB_TT_STRING) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", filename);
+    return mrb_nil_value();
+  }
+
+  return mrb_load(mrb, filename);
+}
+
+static int
+loaded_files_check(mrb_state *mrb, mrb_value filepath)
+{
+  mrb_value loading_files;
+  mrb_value loaded_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\""));
+  int i;
+  for (i = 0; i < RARRAY_LEN(loaded_files); i++) {
+    if (mrb_str_cmp(
+        mrb,
+        mrb_ary_entry(loaded_files, i),
+        filepath) == 0) {
+      return 0;
+    }
+  }
+
+  loading_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\"_"));
+  if (mrb_nil_p(loading_files)) {
+    return 1;
+  }
+  for (i = 0; i < RARRAY_LEN(loading_files); i++) {
+    if (mrb_str_cmp(
+        mrb,
+        mrb_ary_entry(loading_files, i),
+        filepath) == 0) {
+      return 0;
+    }
+  }
+
+  return 1;
+}
+
+static void
+loading_files_add(mrb_state *mrb, mrb_value filepath)
+{
+  mrb_value loading_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\"_"));
+  if (mrb_nil_p(loading_files)) {
+    loading_files = mrb_ary_new(mrb);
+    mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$\"_"), loading_files);
+  }
+  mrb_ary_push(mrb, loading_files, filepath);
+
+  return;
+}
+
+static void
+loading_files_delete(mrb_state *mrb, mrb_value filepath)
+{
+  mrb_value loading_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\"_"));
+  if (!mrb_array_p(loading_files)) {
+    return;
+  }
+  mrb_funcall(mrb, loading_files, "delete", 1, filepath);
+
+  return;
+}
+
+static void
+loaded_files_add(mrb_state *mrb, mrb_value filepath)
+{
+  mrb_value loaded_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\""));
+  mrb_ary_push(mrb, loaded_files, filepath);
+  return;
+}
+
+mrb_value
+mrb_require(mrb_state *mrb, mrb_value filename)
+{
+  mrb_value filepath = find_file(mrb, filename, 1);
+  if (!mrb_nil_p(filepath) && loaded_files_check(mrb, filepath)) {
+    loading_files_add(mrb, filepath);
+    load_file(mrb, filepath);
+    loaded_files_add(mrb, filepath);
+    loading_files_delete(mrb, filepath);
+    return mrb_true_value();
+  }
+
+  return mrb_false_value();
+}
+
+mrb_value
+mrb_f_require(mrb_state *mrb, mrb_value self)
+{
+  mrb_value filename;
+
+  mrb_get_args(mrb, "o", &filename);
+  if (mrb_type(filename) != MRB_TT_STRING) {
+    mrb_raisef(mrb, E_TYPE_ERROR, "can't convert %S into String", filename);
+    return mrb_nil_value();
+  }
+
+  return mrb_require(mrb, filename);
+}
+
+static mrb_value
+mrb_init_load_path(mrb_state *mrb)
+{
+  char *env;
+  mrb_value ary = envpath_to_mrb_ary(mrb, "MRBLIB");
+
+  env = getenv("MRBGEMS_ROOT");
+  if (env)
+    mrb_ary_push(mrb, ary, mrb_str_new_cstr(mrb, env));
+#ifdef MRBGEMS_ROOT
+  else
+    mrb_ary_push(mrb, ary, mrb_str_new_cstr(mrb, MRBGEMS_ROOT));
+#endif
+
+  return ary;
+}
+
+static mrb_value
+mrb_load_error_path(mrb_state *mrb, mrb_value self)
+{
+  return mrb_iv_get(mrb, self, mrb_intern_lit(mrb, "path"));
+}
+
+void
+mrb_mruby_require_gem_init(mrb_state* mrb)
+{
+  char *env;
+  struct RClass *krn;
+  struct RClass *load_error;
+  krn = mrb->kernel_module;
+
+  mrb_define_method(mrb, krn, "load",    mrb_f_load,    MRB_ARGS_REQ(1));
+  mrb_define_method(mrb, krn, "require", mrb_f_require, MRB_ARGS_REQ(1));
+
+  load_error = mrb_define_class(mrb, "LoadError", E_SCRIPT_ERROR);
+  mrb_define_method(mrb, load_error, "path", mrb_load_error_path, MRB_ARGS_NONE());
+
+  mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$:"), mrb_init_load_path(mrb));
+  mrb_gv_set(mrb, mrb_intern_cstr(mrb, "$\""), mrb_ary_new(mrb));
+
+  env = getenv("MRUBY_REQUIRE");
+  if (env != NULL) {
+    int i, envlen;
+    envlen = strlen(env);
+    for (i = 0; i < envlen; i++) {
+      char *ptr = env + i;
+      char *end = strchr(ptr, ',');
+      int len;
+      if (end == NULL) {
+        end = env + envlen;
+      }
+      len = end - ptr;
+
+      mrb_require(mrb, mrb_str_new(mrb, ptr, len));
+      i += len;
+    }
+  }
+}
+
+void
+mrb_mruby_require_gem_final(mrb_state* mrb)
+{
+  mrb_value loaded_files = mrb_gv_get(mrb, mrb_intern_cstr(mrb, "$\""));
+  int i;
+  for (i = 0; i < RARRAY_LEN(loaded_files); i++) {
+    mrb_value f = mrb_ary_entry(loaded_files, i);
+    const char* ext = strrchr(RSTRING_PTR(f), '.');
+    if (ext && strcmp(ext, ".so") == 0) {
+      unload_so_file(mrb, f);
+    }
+  }
+}
+
+/* vim:set et ts=2 sts=2 sw=2 tw=0: */

--- a/mrbgems/pins-mruby-require/src/require.c
+++ b/mrbgems/pins-mruby-require/src/require.c
@@ -482,6 +482,16 @@ mrb_require_load_file( mrb_state * mrb, mrb_value self ) {
   return mrb_true_value();
 }
 
+/*
+static mrb_value
+mruby_gv_get(mrb_state *mrb, mrb_value self)
+{
+  mrb_sym sym;
+  mrb_get_args(mrb, "n", &sym);
+  return mrb_gv_get(mrb,sym);
+}
+*/
+
 void
 mrb_pins_mruby_require_gem_init( mrb_state * mrb ) {
   struct RClass *krn;
@@ -504,6 +514,13 @@ mrb_pins_mruby_require_gem_init( mrb_state * mrb ) {
     mrb_require_load_file,
     MRB_ARGS_REQ(1)
   );
+/*  
+  mrb_define_method(
+    mrb, krn, "___gv_get",
+    mruby_gv_get,
+    MRB_ARGS_REQ(1)
+  );
+*/
 }
 
 void

--- a/mruby_build_config.rb
+++ b/mruby_build_config.rb
@@ -157,7 +157,11 @@ MRuby::Build.new do |conf|
 
   # GEMS INCLUDED AFTER mruby-emb-require WILL BE COMPILED AS SEPARATE object
   # AND MUST BE LOADED AS require 'name-of-the-gem'
-  conf.gem "#{dir}/mrbgems/pins-mruby-require"
+  #if OS == :win
+  # conf.gem "#{dir}/mrbgems/pins-mruby-require"
+  #else
+  conf.gem "#{dir}/mrbgems/mruby-require"
+  #end
 
 
 end


### PR DESCRIPTION
Changes:
* Fixed file track updating while using `Kernel#require` (changed mruby-require gem)
* Fixed issues coming from installing `mattn/mruby-require` on `Mruby_customized`
* Fixed `Kernel#require_relative` to work with both one or two arguments. If only a file name is
provided, it tries to deduce the path using `Kernel#caller` or exception catching, otherwise if
`__FILE__` magic const is passed, it retrieves the file path from that.

This should work on windows too, but it hasn't been tested yet